### PR TITLE
Fix compile error: use diskv.WriteStream, not old diskv.WriteAndSync method

### DIFF
--- a/diskcache/diskcache.go
+++ b/diskcache/diskcache.go
@@ -4,6 +4,7 @@
 package diskcache
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"github.com/peterbourgon/diskv"
@@ -26,7 +27,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 
 func (c *Cache) Set(key string, resp []byte) {
 	key = keyToFilename(key)
-	c.d.WriteAndSync(key, resp)
+	c.d.WriteStream(key, bytes.NewReader(resp), true)
 }
 
 func (c *Cache) Delete(key string) {


### PR DESCRIPTION
This PR fixes a compile error when building httpcache against the current version of `github.com/peterbourgon/diskv`:

```
httpcache$ go build ./...
# github.com/gregjones/httpcache/diskcache
diskcache/diskcache.go:29: c.d.WriteAndSync undefined (type *diskv.Diskv has no field or method WriteAndSync)
```

diskv.WriteAndSync was removed in github.com/peterbourgon/diskv commit
e8bbf390fbf24be1df0f5d62d30591a32ab158c5:
https://github.com/peterbourgon/diskv/commit/e8bbf390fbf24be1df0f5d62d30591a32ab158c5#L2L96.
