### PR TITLE
add memcache implementation of httpcache.Cache

### DIFF
--- a/memcache/appengine.go
+++ b/memcache/appengine.go
@@ -1,0 +1,61 @@
+// +build appengine
+
+// Package memcache provides an implementation of httpcache.Cache that uses App
+// Engine's memcache package to store cached responses.
+//
+// When not built for Google App Engine, this package will provide an
+// implementation that connects to a specified memcached server.  See the
+// memcache.go file in this package for details.
+package memcache
+
+import (
+	"appengine"
+	"appengine/memcache"
+)
+
+// Cache is an implementation of httpcache.Cache that caches responses in App
+// Engine's memcache.
+type Cache struct {
+	appengine.Context
+}
+
+// cacheKey modifies an httpcache key for use in memcache.  Specifically, it
+// prefixes keys to avoid collision with other data stored in memcache.
+func cacheKey(key string) string {
+	return "httpcache:" + key
+}
+
+// Get returns the response corresponding to key if present.
+func (c *Cache) Get(key string) (resp []byte, ok bool) {
+	item, err := memcache.Get(c.Context, cacheKey(key))
+	if err != nil {
+		if err != memcache.ErrCacheMiss {
+			c.Context.Errorf("error getting cached response: %v", err)
+		}
+		return nil, false
+	}
+	return item.Value, true
+}
+
+// Set saves a response to the cache as key.
+func (c *Cache) Set(key string, resp []byte) {
+	item := &memcache.Item{
+		Key:   cacheKey(key),
+		Value: resp,
+	}
+	if err := memcache.Set(c.Context, item); err != nil {
+		c.Context.Errorf("error caching response: %v", err)
+	}
+}
+
+// Delete removes the response with key from the cache.
+func (c *Cache) Delete(key string) {
+	if err := memcache.Delete(c.Context, cacheKey(key)); err != nil {
+		c.Context.Errorf("error deleting cached response: %v", err)
+	}
+}
+
+// New returns a new Cache for the given context.
+func New(ctx appengine.Context) *Cache {
+	return &Cache{ctx}
+}

--- a/memcache/appengine_test.go
+++ b/memcache/appengine_test.go
@@ -1,0 +1,45 @@
+// +build appengine
+
+package memcache
+
+import (
+	"bytes"
+	"testing"
+
+	"appengine/aetest"
+
+	. "launchpad.net/gocheck"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+func (s *S) Test(c *C) {
+	ctx, err := aetest.NewContext(nil)
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	cache := New(ctx)
+
+	key := "testKey"
+	_, ok := cache.Get(key)
+
+	c.Assert(ok, Equals, false)
+
+	val := []byte("some bytes")
+	cache.Set(key, val)
+
+	retVal, ok := cache.Get(key)
+	c.Assert(ok, Equals, true)
+	c.Assert(bytes.Equal(retVal, val), Equals, true)
+
+	cache.Delete(key)
+
+	_, ok = cache.Get(key)
+	c.Assert(ok, Equals, false)
+}

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -1,0 +1,60 @@
+// +build !appengine
+
+// Package memcache provides an implementation of httpcache.Cache that uses
+// gomemcache to store cached responses.
+//
+// When built for Google App Engine, this package will provide an
+// implementation that uses App Engine's memcache service.  See the
+// appengine.go file in this package for details.
+package memcache
+
+import (
+	"github.com/bradfitz/gomemcache/memcache"
+)
+
+// Cache is an implementation of httpcache.Cache that caches responses in a
+// memcache server.
+type Cache struct {
+	*memcache.Client
+}
+
+// cacheKey modifies an httpcache key for use in memcache.  Specifically, it
+// prefixes keys to avoid collision with other data stored in memcache.
+func cacheKey(key string) string {
+	return "httpcache:" + key
+}
+
+// Get returns the response corresponding to key if present.
+func (c *Cache) Get(key string) (resp []byte, ok bool) {
+	item, err := c.Client.Get(cacheKey(key))
+	if err != nil {
+		return nil, false
+	}
+	return item.Value, true
+}
+
+// Set saves a response to the cache as key.
+func (c *Cache) Set(key string, resp []byte) {
+	item := &memcache.Item{
+		Key:   cacheKey(key),
+		Value: resp,
+	}
+	c.Client.Set(item)
+}
+
+// Delete removes the response with key from the cache.
+func (c *Cache) Delete(key string) {
+	c.Client.Delete(cacheKey(key))
+}
+
+// New returns a new Cache using the provided memcache server(s) with equal
+// weight. If a server is listed multiple times, it gets a proportional amount
+// of weight.
+func New(server ...string) *Cache {
+	return NewWithClient(memcache.New(server...))
+}
+
+// NewWithClient returns a new Cache with the given memcache client.
+func NewWithClient(client *memcache.Client) *Cache {
+	return &Cache{client}
+}

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -1,0 +1,51 @@
+// +build !appengine
+
+package memcache
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"testing"
+
+	. "launchpad.net/gocheck"
+)
+
+const testServer = "localhost:11211"
+
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+func (s *S) SetUpSuite(c *C) {
+	conn, err := net.Dial("tcp", testServer)
+	if err != nil {
+		// TODO: rather than skip the test, fall back to a faked memcached server
+		c.Skip(fmt.Sprintf("skipping test; no server running at %s", testServer))
+	}
+	conn.Write([]byte("flush_all\r\n")) // flush memcache
+	conn.Close()
+}
+
+func (s *S) Test(c *C) {
+	cache := New(testServer)
+
+	key := "testKey"
+	_, ok := cache.Get(key)
+
+	c.Assert(ok, Equals, false)
+
+	val := []byte("some bytes")
+	cache.Set(key, val)
+
+	retVal, ok := cache.Get(key)
+	c.Assert(ok, Equals, true)
+	c.Assert(bytes.Equal(retVal, val), Equals, true)
+
+	cache.Delete(key)
+
+	_, ok = cache.Get(key)
+	c.Assert(ok, Equals, false)
+}


### PR DESCRIPTION
This provides two separate implementations, one that uses App Engine's
memcache service, and one that uses the gomemcache library to connect to
a specified memcached server.  The correct implementation is built based
on the presence of the "appengine" build constraint.

Tests for the non-App Engine implementation expect to connect to a
memcached server on localhost:11211 (the default memcached port).  If a
local server is not found, the tests are skipped.  Eventually this could
be replaced with a very simple TCP listener that implements enough of
the memcache protocol to run the tests.
