### PR TITLE
proper conversion of 304 responses

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -178,9 +179,12 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			// Replace the 304 response with the one from cache, but update with some new headers
 			headersToMerge := getHopByHopHeaders(resp)
 			for _, headerKey := range headersToMerge {
-				cachedResp.Header.Set(headerKey, resp.Header.Get(headerKey))
+				key := http.CanonicalHeaderKey(headerKey)
+				if v, ok := resp.Header[key]; ok {
+					cachedResp.Header[key] = v
+				}
 			}
-			cachedResp.Status = http.StatusText(http.StatusOK)
+			cachedResp.Status = fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK))
 			cachedResp.StatusCode = http.StatusOK
 
 			resp = cachedResp

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -157,6 +157,11 @@ func (s *S) TestGetWithEtag(c *C) {
 	defer resp2.Body.Close()
 	c.Assert(err2, IsNil)
 	c.Assert(resp2.Header.Get(XFromCache), Equals, "1")
+
+	// additional assertions to verify that 304 response is converted properly
+	c.Assert(resp2.Status, Equals, "200 OK")
+	_, ok := resp2.Header["Connection"]
+	c.Assert(ok, Equals, false)
 }
 
 func (s *S) TestGetWithLastModified(c *C) {


### PR DESCRIPTION
- include status code in cachedResp.Status field
- only copy over headers that are populated in the original response

fixes #22
