### PR TITLE
Collision between methods

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -39,7 +39,7 @@ type Cache interface {
 
 // cacheKey returns the cache key for req.
 func cacheKey(req *http.Request) string {
-	return req.URL.String()
+	return fmt.Sprintf("%s_%s", req.Method, req.URL.String())
 }
 
 // CachedResponse returns the cached http.Response for req if present, and nil

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -401,3 +401,18 @@ func (s *S) TestMaxStaleValue(c *C) {
 
 	c.Assert(getFreshness(respHeaders, reqHeaders), Equals, stale)
 }
+
+func (s *S) TestGetAndHeadSameUrl(c *C) {
+	req, err := http.NewRequest("HEAD", s.server.URL+"/", nil)
+	req.Header.Set("Accept", "text/plain")
+	resp, err := s.client.Do(req)
+	defer resp.Body.Close()
+	c.Assert(err, IsNil)
+	c.Assert(resp.Header.Get(XFromCache), Equals, "")
+
+	req2, err := http.NewRequest("GET", s.server.URL+"/", nil)
+	resp2, err2 := s.client.Do(req2)
+	defer resp2.Body.Close()
+	c.Assert(err2, IsNil)
+	c.Assert(resp2.Header.Get(XFromCache), Equals, "")
+}


### PR DESCRIPTION
Request with same URL and different Method are cached as same.

To avoid it, the key is now a composition of Url + Method.

Other parameter to be take in count is the header, eg the ``Accept` header changes the output of the request.
