### PR TITLE
Add leveldbcache provides an implementation of httpcache.Cache

### DIFF
--- a/leveldbcache/leveldbcache.go
+++ b/leveldbcache/leveldbcache.go
@@ -1,0 +1,51 @@
+// Package leveldbcache provides an implementation of httpcache.Cache that
+// uses github.com/syndtr/goleveldb/leveldb
+package leveldbcache
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+// Cache is an implementation of httpcache.Cache with leveldb storage
+type Cache struct {
+	db *leveldb.DB
+}
+
+// Get returns the response corresponding to key if present
+func (c *Cache) Get(key string) (resp []byte, ok bool) {
+	var err error
+	resp, err = c.db.Get([]byte(key), nil)
+	if err != nil {
+		return []byte{}, false
+	}
+	return resp, true
+}
+
+// Set saves a response to the cache as key
+func (c *Cache) Set(key string, resp []byte) {
+	c.db.Put([]byte(key), resp, nil)
+}
+
+// Delete removes the response with key from the cache
+func (c *Cache) Delete(key string) {
+	c.db.Delete([]byte(key), nil)
+}
+
+// New returns a new Cache that will store leveldb in path
+func New(path string) (*Cache, error) {
+	cache := &Cache{}
+
+	var err error
+	cache.db, err = leveldb.OpenFile(path, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	return cache, nil
+}
+
+// NewWithDB returns a new Cache using the provided leveldb as underlying
+// storage.
+func NewWithDB(db *leveldb.DB) *Cache {
+	return &Cache{db}
+}

--- a/leveldbcache/leveldbcache_test.go
+++ b/leveldbcache/leveldbcache_test.go
@@ -1,0 +1,45 @@
+package leveldbcache
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+func (s *S) Test(c *C) {
+	tempDir, err := ioutil.TempDir("", "httpcache")
+	if err != nil {
+		c.Fatalf("TempDir,: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cache, err := New(fmt.Sprintf("%s%c%s", tempDir, os.PathSeparator, "db"))
+	if err != nil {
+		c.Fatalf("New leveldb,: %v", err)
+	}
+	key := "testKey"
+	_, ok := cache.Get(key)
+
+	c.Assert(ok, Equals, false)
+
+	val := []byte("some bytes")
+	cache.Set(key, val)
+
+	retVal, ok := cache.Get(key)
+	c.Assert(ok, Equals, true)
+	c.Assert(bytes.Equal(retVal, val), Equals, true)
+	cache.Delete(key)
+
+	_, ok = cache.Get(key)
+	c.Assert(ok, Equals, false)
+}


### PR DESCRIPTION
LevelDB is a light-weight, single-purpose library for persistence with bindings to many platforms.

Seems better than diskv :-P