### PR TITLE
Add a cache fallback strategy

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -184,7 +184,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			cachedResp.StatusCode = http.StatusOK
 
 			resp = cachedResp
-		} else if (err != nil || (cachedResp != nil && cachedResp.StatusCode >= 500)) &&
+		} else if (err != nil || (cachedResp != nil && resp.StatusCode >= 500)) &&
 			req.Method == "GET" && canStaleOnError(cachedResp.Header, req.Header) {
 			// In case of transport failure and stale-if-error activated, returns cached content
 			// when available

--- a/httpcache.go
+++ b/httpcache.go
@@ -184,7 +184,8 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			cachedResp.StatusCode = http.StatusOK
 
 			resp = cachedResp
-		} else if err != nil && req.Method == "GET" && canStaleOnError(cachedResp.Header, req.Header) {
+		} else if (err != nil || (cachedResp != nil && cachedResp.StatusCode >= 500)) &&
+			req.Method == "GET" && canStaleOnError(cachedResp.Header, req.Header) {
 			// In case of transport failure and stale-if-error activated, returns cached content
 			// when available
 			cachedResp.Status = fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK))

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -620,6 +620,13 @@ func (s *S) TestStaleIfErrorRequestLifetime(c *C) {
 	c.Assert(err, Equals, nil)
 	c.Assert(resp, NotNil)
 
+	// Same for http errors
+	tmock.response = &http.Response{StatusCode: http.StatusInternalServerError}
+	tmock.err = nil
+	resp, err = t.RoundTrip(r)
+	c.Assert(err, Equals, nil)
+	c.Assert(resp, NotNil)
+
 	// If failure last more than max stale, error is returned
 	clock = &fakeClock{elapsed: 200 * time.Second}
 	resp, err = t.RoundTrip(r)


### PR DESCRIPTION
When `CacheFallback` property is set to `true`, the cached result is
returned no matter what in case of network error with the client
request.