### PR TITLE
Add support for cancellation

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -127,10 +127,10 @@ type Transport struct {
 	Cache     Cache
 	// If true, responses returned from the cache will be given an extra header, X-From-Cache
 	MarkCachedResponses bool
+	// guards modReq
+	mu sync.RWMutex
 	// Mapping of original request => cloned
 	modReq map[*http.Request]*http.Request
-	// guards clonedReqs
-	mu sync.RWMutex
 }
 
 // NewTransport returns a new Transport with the

--- a/httpcache.go
+++ b/httpcache.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -224,6 +225,20 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		t.Cache.Delete(cacheKey)
 	}
 	return resp, nil
+}
+
+// CancelRequest calls CancelRequest on the underlaying transport if implemented or
+// throw a warning otherwise.
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	tr, ok := t.Transport.(canceler)
+	if !ok {
+		log.Printf("httpcache: Client Transport of type %T doesn't support CancelRequest; Timeout not supported", t.Transport)
+		return
+	}
+	tr.CancelRequest(req)
 }
 
 // ErrNoDateHeader indicates that the HTTP headers contained no Date header.


### PR DESCRIPTION
This allows the use of `http.Client` `Timeout` property or
`ctxhttp.Client` with a context with deadline.