### PR TITLE
Avoid using defer where it's easy to do so.

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -65,23 +65,23 @@ type MemoryCache struct {
 // Get returns the []byte representation of the response and true if present, false if not
 func (c *MemoryCache) Get(key string) (resp []byte, ok bool) {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
 	resp, ok = c.items[key]
+	c.mu.RUnlock()
 	return resp, ok
 }
 
 // Set saves response resp to the cache with key
 func (c *MemoryCache) Set(key string, resp []byte) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.items[key] = resp
+	c.mu.Unlock()
 }
 
 // Delete removes key from the cache
 func (c *MemoryCache) Delete(key string) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	delete(c.items, key)
+	c.mu.Unlock()
 }
 
 // NewMemoryCache returns a new Cache that will store items in an in-memory map
@@ -159,7 +159,6 @@ func varyMatches(cachedResp *http.Response, req *http.Request) bool {
 // setModReq maintains a mapping between original requests and their associated cloned requests
 func (t *Transport) setModReq(orig, mod *http.Request) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	if t.modReq == nil {
 		t.modReq = make(map[*http.Request]*http.Request)
 	}
@@ -168,6 +167,7 @@ func (t *Transport) setModReq(orig, mod *http.Request) {
 	} else {
 		t.modReq[orig] = mod
 	}
+	t.mu.Unlock()
 }
 
 // RoundTrip takes a Request and returns a Response


### PR DESCRIPTION
Since `defer` has a somewhat non-negligible performance cost, avoid using it in places where it's easy to do so. See #36 for details.

Fixes #36.