### PR TITLE
Add Status and StatusCode to mock responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d -s .)
+  - diff -u <(echo -n) <(gofmt -d .)
   - go tool vet .
   - go test -v -race ./...

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -565,6 +565,8 @@ func (s *S) TestStaleIfErrorRequest(c *C) {
 	now := time.Now()
 	tmock := transportMock{
 		response: &http.Response{
+			Status:     http.StatusText(http.StatusOK),
+			StatusCode: http.StatusOK,
 			Header: http.Header{
 				"Date":          []string{now.Format(time.RFC1123)},
 				"Cache-Control": []string{"no-cache"},
@@ -595,6 +597,8 @@ func (s *S) TestStaleIfErrorRequestLifetime(c *C) {
 	now := time.Now()
 	tmock := transportMock{
 		response: &http.Response{
+			Status:     http.StatusText(http.StatusOK),
+			StatusCode: http.StatusOK,
 			Header: http.Header{
 				"Date":          []string{now.Format(time.RFC1123)},
 				"Cache-Control": []string{"no-cache"},
@@ -637,6 +641,8 @@ func (s *S) TestStaleIfErrorResponse(c *C) {
 	now := time.Now()
 	tmock := transportMock{
 		response: &http.Response{
+			Status:     http.StatusText(http.StatusOK),
+			StatusCode: http.StatusOK,
 			Header: http.Header{
 				"Date":          []string{now.Format(time.RFC1123)},
 				"Cache-Control": []string{"no-cache, stale-if-error"},
@@ -666,6 +672,8 @@ func (s *S) TestStaleIfErrorResponseLifetime(c *C) {
 	now := time.Now()
 	tmock := transportMock{
 		response: &http.Response{
+			Status:     http.StatusText(http.StatusOK),
+			StatusCode: http.StatusOK,
 			Header: http.Header{
 				"Date":          []string{now.Format(time.RFC1123)},
 				"Cache-Control": []string{"no-cache, stale-if-error=100"},


### PR DESCRIPTION
Go 1.6 errors if Responses don't have a valid status code, which meant
these tests were failing.

Fixes #38