### PR TITLE
Change tests to use standard library, more idiomatic style.

### DIFF
--- a/diskcache/diskcache_test.go
+++ b/diskcache/diskcache_test.go
@@ -5,20 +5,12 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type S struct{}
-
-var _ = Suite(&S{})
-
-func (s *S) Test(c *C) {
+func TestDiskCache(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "httpcache")
 	if err != nil {
-		c.Fatalf("TempDir,: %v", err)
+		t.Fatalf("TempDir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
 
@@ -26,18 +18,25 @@ func (s *S) Test(c *C) {
 
 	key := "testKey"
 	_, ok := cache.Get(key)
-
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("retrieved key before adding it")
+	}
 
 	val := []byte("some bytes")
 	cache.Set(key, val)
 
 	retVal, ok := cache.Get(key)
-	c.Assert(ok, Equals, true)
-	c.Assert(bytes.Equal(retVal, val), Equals, true)
+	if !ok {
+		t.Fatal("could not retrieve an element we just added")
+	}
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
+	}
 
 	cache.Delete(key)
 
 	_, ok = cache.Get(key)
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("deleted key still present")
+	}
 }

--- a/leveldbcache/leveldbcache_test.go
+++ b/leveldbcache/leveldbcache_test.go
@@ -2,44 +2,45 @@ package leveldbcache
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
-
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type S struct{}
-
-var _ = Suite(&S{})
-
-func (s *S) Test(c *C) {
+func TestDiskCache(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "httpcache")
 	if err != nil {
-		c.Fatalf("TempDir,: %v", err)
+		t.Fatalf("TempDir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	cache, err := New(fmt.Sprintf("%s%c%s", tempDir, os.PathSeparator, "db"))
+	cache, err := New(filepath.Join(tempDir, "db"))
 	if err != nil {
-		c.Fatalf("New leveldb,: %v", err)
+		t.Fatalf("New leveldb,: %v", err)
 	}
+
 	key := "testKey"
 	_, ok := cache.Get(key)
-
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("retrieved key before adding it")
+	}
 
 	val := []byte("some bytes")
 	cache.Set(key, val)
 
 	retVal, ok := cache.Get(key)
-	c.Assert(ok, Equals, true)
-	c.Assert(bytes.Equal(retVal, val), Equals, true)
+	if !ok {
+		t.Fatal("could not retrieve an element we just added")
+	}
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
+	}
+
 	cache.Delete(key)
 
 	_, ok = cache.Get(key)
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("deleted key still present")
+	}
 }

--- a/memcache/appengine_test.go
+++ b/memcache/appengine_test.go
@@ -7,20 +7,12 @@ import (
 	"testing"
 
 	"appengine/aetest"
-
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type S struct{}
-
-var _ = Suite(&S{})
-
-func (s *S) Test(c *C) {
+func TestAppEngine(t *testing.T) {
 	ctx, err := aetest.NewContext(nil)
 	if err != nil {
-		c.Fatal(err)
+		t.Fatal(err)
 	}
 	defer ctx.Close()
 
@@ -28,18 +20,25 @@ func (s *S) Test(c *C) {
 
 	key := "testKey"
 	_, ok := cache.Get(key)
-
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("retrieved key before adding it")
+	}
 
 	val := []byte("some bytes")
 	cache.Set(key, val)
 
 	retVal, ok := cache.Get(key)
-	c.Assert(ok, Equals, true)
-	c.Assert(bytes.Equal(retVal, val), Equals, true)
+	if !ok {
+		t.Fatal("could not retrieve an element we just added")
+	}
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
+	}
 
 	cache.Delete(key)
 
 	_, ok = cache.Get(key)
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("deleted key still present")
+	}
 }

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -4,48 +4,44 @@ package memcache
 
 import (
 	"bytes"
-	"fmt"
 	"net"
 	"testing"
-
-	. "gopkg.in/check.v1"
 )
 
 const testServer = "localhost:11211"
 
-func Test(t *testing.T) { TestingT(t) }
-
-type S struct{}
-
-var _ = Suite(&S{})
-
-func (s *S) SetUpSuite(c *C) {
+func TestMemCache(t *testing.T) {
 	conn, err := net.Dial("tcp", testServer)
 	if err != nil {
 		// TODO: rather than skip the test, fall back to a faked memcached server
-		c.Skip(fmt.Sprintf("skipping test; no server running at %s", testServer))
+		t.Skipf("skipping test; no server running at %s", testServer)
 	}
 	conn.Write([]byte("flush_all\r\n")) // flush memcache
 	conn.Close()
-}
 
-func (s *S) Test(c *C) {
 	cache := New(testServer)
 
 	key := "testKey"
 	_, ok := cache.Get(key)
-
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("retrieved key before adding it")
+	}
 
 	val := []byte("some bytes")
 	cache.Set(key, val)
 
 	retVal, ok := cache.Get(key)
-	c.Assert(ok, Equals, true)
-	c.Assert(bytes.Equal(retVal, val), Equals, true)
+	if !ok {
+		t.Fatal("could not retrieve an element we just added")
+	}
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
+	}
 
 	cache.Delete(key)
 
 	_, ok = cache.Get(key)
-	c.Assert(ok, Equals, false)
+	if ok {
+		t.Fatal("deleted key still present")
+	}
 }


### PR DESCRIPTION
The motivation for using idiomatic style and standard library for tests is that it's more universal, and more familiar to a larger set of people. It makes it easier to read, modify tests for experienced Go programmers. It does not require thorough knowledge and familiarity with custom APIs.

Resolves #41.

This commit is largely based on previous work by @uovobw in https://github.com/sourcegraph/httpcache/pull/3, modified by me to improve error messages, style, and address preliminary review comments.