### PR TITLE
Resolve FD leaks with Redis, add expiration to memcached and redis, update travis to test redis and memcached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: go
 go:
   - 1.6
-  - 1.7
+  - 1.7.5
+  - 1.8
   - tip
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
   - 1.7.5
   - 1.8
   - tip
+services:
+  - memcached
+  - redis
 matrix:
   allow_failures:
     - go: tip

--- a/diskcache/diskcache.go
+++ b/diskcache/diskcache.go
@@ -8,7 +8,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"io"
-	"time"
 
 	"github.com/peterbourgon/diskv"
 )
@@ -28,8 +27,8 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return resp, true
 }
 
-// Set saves a response to the cache as key. Duration is not implemented.
-func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
+// Set saves a response to the cache as key.
+func (c *Cache) Set(key string, resp []byte) {
 	key = keyToFilename(key)
 	c.d.WriteStream(key, bytes.NewReader(resp), true)
 }

--- a/diskcache/diskcache.go
+++ b/diskcache/diskcache.go
@@ -28,7 +28,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return resp, true
 }
 
-// Set saves a response to the cache as key
+// Set saves a response to the cache as key. Duration is not implemented.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	key = keyToFilename(key)
 	c.d.WriteStream(key, bytes.NewReader(resp), true)

--- a/diskcache/diskcache.go
+++ b/diskcache/diskcache.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
-	"github.com/peterbourgon/diskv"
 	"io"
+	"time"
+
+	"github.com/peterbourgon/diskv"
 )
 
 // Cache is an implementation of httpcache.Cache that supplements the in-memory map with persistent storage
@@ -27,7 +29,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key
-func (c *Cache) Set(key string, resp []byte) {
+func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	key = keyToFilename(key)
 	c.d.WriteStream(key, bytes.NewReader(resp), true)
 }

--- a/diskcache/diskcache_test.go
+++ b/diskcache/diskcache_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestDiskCache(t *testing.T) {
@@ -23,7 +24,7 @@ func TestDiskCache(t *testing.T) {
 	}
 
 	val := []byte("some bytes")
-	cache.Set(key, val)
+	cache.Set(key, val, time.Second)
 
 	retVal, ok := cache.Get(key)
 	if !ok {

--- a/httpcache.go
+++ b/httpcache.go
@@ -523,14 +523,14 @@ func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
 func getEndToEndHeaders(respHeaders http.Header) []string {
 	// These headers are always hop-by-hop
 	hopByHopHeaders := map[string]struct{}{
-		"Connection":          struct{}{},
-		"Keep-Alive":          struct{}{},
-		"Proxy-Authenticate":  struct{}{},
-		"Proxy-Authorization": struct{}{},
-		"Te":                struct{}{},
-		"Trailers":          struct{}{},
-		"Transfer-Encoding": struct{}{},
-		"Upgrade":           struct{}{},
+		"Connection":          {},
+		"Keep-Alive":          {},
+		"Proxy-Authenticate":  {},
+		"Proxy-Authorization": {},
+		"Te":                {},
+		"Trailers":          {},
+		"Transfer-Encoding": {},
+		"Upgrade":           {},
 	}
 
 	for _, extra := range strings.Split(respHeaders.Get("connection"), ",") {
@@ -540,7 +540,7 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 		}
 	}
 	endToEndHeaders := []string{}
-	for respHeader, _ := range respHeaders {
+	for respHeader := range respHeaders {
 		if _, ok := hopByHopHeaders[respHeader]; !ok {
 			endToEndHeaders = append(endToEndHeaders, respHeader)
 		}

--- a/httpcache.go
+++ b/httpcache.go
@@ -33,7 +33,8 @@ type Cache interface {
 	// Get returns the []byte representation of a cached response and a bool
 	// set to true if the value isn't empty
 	Get(key string) (responseBytes []byte, ok bool)
-	// Set stores the []byte representation of a response against a key
+	// Set stores the []byte representation of a response against a key with the
+	// remaining cache duration.
 	Set(key string, responseBytes []byte, duration time.Duration)
 	// Delete removes the value associated with the key
 	Delete(key string)
@@ -70,7 +71,7 @@ func (c *MemoryCache) Get(key string) (resp []byte, ok bool) {
 	return resp, ok
 }
 
-// Set saves response resp to the cache with key
+// Set saves response resp to the cache with key. Duration is not implemented.
 func (c *MemoryCache) Set(key string, resp []byte, duration time.Duration) {
 	c.mu.Lock()
 	c.items[key] = resp

--- a/leveldbcache/leveldbcache.go
+++ b/leveldbcache/leveldbcache.go
@@ -23,7 +23,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return resp, true
 }
 
-// Set saves a response to the cache as key
+// Set saves a response to the cache as key. Duration is not implemented.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	c.db.Put([]byte(key), resp, nil)
 }

--- a/leveldbcache/leveldbcache.go
+++ b/leveldbcache/leveldbcache.go
@@ -3,6 +3,8 @@
 package leveldbcache
 
 import (
+	"time"
+
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -22,7 +24,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key
-func (c *Cache) Set(key string, resp []byte) {
+func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	c.db.Put([]byte(key), resp, nil)
 }
 

--- a/leveldbcache/leveldbcache.go
+++ b/leveldbcache/leveldbcache.go
@@ -3,8 +3,6 @@
 package leveldbcache
 
 import (
-	"time"
-
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -23,8 +21,8 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return resp, true
 }
 
-// Set saves a response to the cache as key. Duration is not implemented.
-func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
+// Set saves a response to the cache as key.
+func (c *Cache) Set(key string, resp []byte) {
 	c.db.Put([]byte(key), resp, nil)
 }
 

--- a/leveldbcache/leveldbcache_test.go
+++ b/leveldbcache/leveldbcache_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestDiskCache(t *testing.T) {
@@ -27,7 +28,7 @@ func TestDiskCache(t *testing.T) {
 	}
 
 	val := []byte("some bytes")
-	cache.Set(key, val)
+	cache.Set(key, val, time.Second)
 
 	retVal, ok := cache.Get(key)
 	if !ok {

--- a/memcache/appengine.go
+++ b/memcache/appengine.go
@@ -39,11 +39,12 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return item.Value, true
 }
 
-// Set saves a response to the cache as key.
+// Set saves a response to the cache as key and set to expire after the duration.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	item := &memcache.Item{
-		Key:   cacheKey(key),
-		Value: resp,
+		Key:        cacheKey(key),
+		Value:      resp,
+		Expiration: (int32)(duration.Seconds()),
 	}
 	if err := memcache.Set(c.Context, item); err != nil {
 		c.Context.Errorf("error caching response: %v", err)

--- a/memcache/appengine.go
+++ b/memcache/appengine.go
@@ -9,6 +9,8 @@
 package memcache
 
 import (
+	"time"
+
 	"appengine"
 	"appengine/memcache"
 )
@@ -38,7 +40,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key.
-func (c *Cache) Set(key string, resp []byte) {
+func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	item := &memcache.Item{
 		Key:   cacheKey(key),
 		Value: resp,

--- a/memcache/appengine.go
+++ b/memcache/appengine.go
@@ -9,8 +9,6 @@
 package memcache
 
 import (
-	"time"
-
 	"appengine"
 	"appengine/memcache"
 )
@@ -40,7 +38,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key and set to expire after the duration.
-func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
+func (c *Cache) Set(key string, resp []byte) {
 	item := &memcache.Item{
 		Key:        cacheKey(key),
 		Value:      resp,

--- a/memcache/appengine_test.go
+++ b/memcache/appengine_test.go
@@ -5,6 +5,7 @@ package memcache
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"appengine/aetest"
 )
@@ -25,7 +26,7 @@ func TestAppEngine(t *testing.T) {
 	}
 
 	val := []byte("some bytes")
-	cache.Set(key, val)
+	cache.Set(key, val, time.Second)
 
 	retVal, ok := cache.Get(key)
 	if !ok {

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -9,6 +9,8 @@
 package memcache
 
 import (
+	"time"
+
 	"github.com/bradfitz/gomemcache/memcache"
 )
 
@@ -34,7 +36,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key.
-func (c *Cache) Set(key string, resp []byte) {
+func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	item := &memcache.Item{
 		Key:   cacheKey(key),
 		Value: resp,

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -38,8 +38,9 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 // Set saves a response to the cache as key.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	item := &memcache.Item{
-		Key:   cacheKey(key),
-		Value: resp,
+		Key:        cacheKey(key),
+		Value:      resp,
+		Expiration: (int32)(duration.Seconds()),
 	}
 	c.Client.Set(item)
 }

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -9,8 +9,6 @@
 package memcache
 
 import (
-	"time"
-
 	"github.com/bradfitz/gomemcache/memcache"
 )
 
@@ -36,11 +34,10 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key and set to expire after the duration.
-func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
+func (c *Cache) Set(key string, resp []byte) {
 	item := &memcache.Item{
-		Key:        cacheKey(key),
-		Value:      resp,
-		Expiration: (int32)(duration.Seconds()),
+		Key:   cacheKey(key),
+		Value: resp,
 	}
 	c.Client.Set(item)
 }

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -35,7 +35,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return item.Value, true
 }
 
-// Set saves a response to the cache as key.
+// Set saves a response to the cache as key and set to expire after the duration.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	item := &memcache.Item{
 		Key:        cacheKey(key),

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"net"
 	"testing"
+	"time"
 )
 
 const testServer = "localhost:11211"
@@ -28,7 +29,7 @@ func TestMemCache(t *testing.T) {
 	}
 
 	val := []byte("some bytes")
-	cache.Set(key, val)
+	cache.Set(key, val, time.Second)
 
 	retVal, ok := cache.Get(key)
 	if !ok {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -32,8 +32,8 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 
 // Set saves a response to the cache as key and set to expire after the duration.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
-	if duration > time.Hour {
-		duration = time.Hour
+	if duration > time.Minute*30 {
+		duration = time.Minute * 30
 	}
 	conn := c.Pool.Get()
 	conn.Do("SETEX", cacheKey(key), (int)(duration.Seconds()), resp)

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -7,7 +7,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
-// cache is an implementation of httpcache.Cache that caches responses in a
+// Cache is an implementation of httpcache.Cache that caches responses in a
 // redis server.
 type Cache struct {
 	*redis.Pool
@@ -30,7 +30,7 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return item, true
 }
 
-// Set saves a response to the cache as key.
+// Set saves a response to the cache as key and set to expire after the duration.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	conn := c.Pool.Get()
 	conn.Do("SETEX", cacheKey(key), (int)(duration.Seconds()), resp)

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,8 +2,6 @@
 package redis
 
 import (
-	"time"
-
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -31,12 +29,9 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key and set to expire after the duration.
-func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
-	if duration > time.Minute*30 {
-		duration = time.Minute * 30
-	}
+func (c *Cache) Set(key string, resp []byte) {
 	conn := c.Pool.Get()
-	conn.Do("SETEX", cacheKey(key), (int)(duration.Seconds()), resp)
+	conn.Do("SET", cacheKey(key), resp)
 	conn.Close()
 }
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -32,6 +32,9 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 
 // Set saves a response to the cache as key and set to expire after the duration.
 func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
+	if duration > time.Hour {
+		duration = time.Hour
+	}
 	conn := c.Pool.Get()
 	conn.Do("SETEX", cacheKey(key), (int)(duration.Seconds()), resp)
 	conn.Close()

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,7 +1,11 @@
 // Package redis provides a redis interface for http caching.
 package redis
 
-import "github.com/garyburd/redigo/redis"
+import (
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+)
 
 // cache is an implementation of httpcache.Cache that caches responses in a
 // redis server.
@@ -27,9 +31,9 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 }
 
 // Set saves a response to the cache as key.
-func (c *Cache) Set(key string, resp []byte) {
+func (c *Cache) Set(key string, resp []byte, duration time.Duration) {
 	conn := c.Pool.Get()
-	conn.Do("SET", cacheKey(key), resp)
+	conn.Do("SETEX", cacheKey(key), (int)(duration.Seconds()), resp)
 	conn.Close()
 }
 

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -152,5 +152,4 @@ func TestConcurrency(t *testing.T) {
 	for i := 0; i < len(data); i++ {
 		<-retChan
 	}
-
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -38,7 +38,7 @@ func TestRedisCache(t *testing.T) {
 	}
 
 	val := []byte("some bytes")
-	cache.Set(key, val)
+	cache.Set(key, val, 5*time.Second)
 
 	retVal, ok := cache.Get(key)
 	if !ok {
@@ -54,4 +54,103 @@ func TestRedisCache(t *testing.T) {
 	if ok {
 		t.Fatal("deleted key still present")
 	}
+
+	cache.Set(key, val, 0*time.Second)
+	time.Sleep(500 * time.Millisecond)
+	retVal, ok = cache.Get(key)
+	if ok {
+		t.Fatal("retrieved an element that should have expired")
+	}
+}
+
+func TestConcurrency(t *testing.T) {
+	type testData struct {
+		key      string
+		value    []byte
+		duration time.Duration
+	}
+
+	data := []testData{
+		testData{"one", []byte("1"), time.Second * 1},
+		testData{"two", []byte("2"), time.Second * 1},
+		testData{"three", []byte("3"), time.Second * 1},
+		testData{"four", []byte("4"), time.Second * 1},
+		testData{"five", []byte("5"), time.Second * 1},
+		testData{"six", []byte("6"), time.Second * 1},
+		testData{"seven", []byte("7"), time.Second * 1},
+		testData{"eight", []byte("8"), time.Second * 1},
+		testData{"nine", []byte("9"), time.Second * 1},
+		testData{"ten", []byte("10"), time.Second * 1},
+	}
+
+	pool := &redis.Pool{
+		MaxIdle:     10,
+		IdleTimeout: 60 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial("tcp", "127.0.0.1:6379")
+			if err != nil {
+				return nil, err
+			}
+			return c, err
+		},
+	}
+
+	cache := NewWithClient(pool)
+
+	retChan := make(chan error)
+
+	// Add the entries
+	for _, d := range data {
+		go func(c *Cache, ret chan error, d testData) {
+			c.Set(d.key, d.value, d.duration)
+			retChan <- nil
+		}(cache, retChan, d)
+	}
+
+	// Wait for the goroutines to finish
+	for i := 0; i < len(data); i++ {
+		<-retChan
+	}
+
+	// Check the entries exist
+	for _, d := range data {
+		go func(c *Cache, ret chan error, d testData) {
+			retVal, ok := c.Get(d.key)
+			if !ok {
+				t.Log("could not retrieve an element we just added")
+				t.Fail()
+			}
+			if !bytes.Equal(retVal, d.value) {
+				t.Log("retrieved a different value than what we put in")
+				t.Fail()
+			}
+			retChan <- nil
+		}(cache, retChan, d)
+	}
+
+	// Wait for the goroutines to finish
+	for i := 0; i < len(data); i++ {
+		<-retChan
+	}
+
+	// Wait for the strings to expire
+	time.Sleep(time.Second * 2)
+
+	// Make sure we get invalid responses since they were expired by redis
+	for _, d := range data {
+		go func(c *Cache, ret chan error, d testData) {
+			_, ok := c.Get(d.key)
+			if ok {
+				t.Log("retrieved an element that should have expired")
+				t.Fail()
+			}
+			retChan <- nil
+		}(cache, retChan, d)
+	}
+
+	// Wait for the goroutines to finish
+	for i := 0; i < len(data); i++ {
+		<-retChan
+	}
+
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -71,16 +71,16 @@ func TestConcurrency(t *testing.T) {
 	}
 
 	data := []testData{
-		testData{"one", []byte("1"), time.Second * 1},
-		testData{"two", []byte("2"), time.Second * 1},
-		testData{"three", []byte("3"), time.Second * 1},
-		testData{"four", []byte("4"), time.Second * 1},
-		testData{"five", []byte("5"), time.Second * 1},
-		testData{"six", []byte("6"), time.Second * 1},
-		testData{"seven", []byte("7"), time.Second * 1},
-		testData{"eight", []byte("8"), time.Second * 1},
-		testData{"nine", []byte("9"), time.Second * 1},
-		testData{"ten", []byte("10"), time.Second * 1},
+		{"one", []byte("1"), time.Second * 1},
+		{"two", []byte("2"), time.Second * 1},
+		{"three", []byte("3"), time.Second * 1},
+		{"four", []byte("4"), time.Second * 1},
+		{"five", []byte("5"), time.Second * 1},
+		{"six", []byte("6"), time.Second * 1},
+		{"seven", []byte("7"), time.Second * 1},
+		{"eight", []byte("8"), time.Second * 1},
+		{"nine", []byte("9"), time.Second * 1},
+		{"ten", []byte("10"), time.Second * 1},
 	}
 
 	pool := &redis.Pool{


### PR DESCRIPTION
I ran into an issue using redis where file descriptors were being leaked.

Resolving this also showed that it is possible that caching may not always occur in highly concurrent situations. This further lead to redis memory usage (strings) constantly increasing but rarely deleting strings.

The best solution I could think of at the time was to add cacheDuration to .Set and use SETEX to allow strings to naturally expire, since it could be very possible that I would not touch a page for several hours after it expires.

I also added the same expiration to memcached and added both services to travis-ci so the tests are checked.

There may be a better alternative I am overlooking.