### PR TITLE
README: More consistent formatting with other Go packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Cache Backends
 License
 -------
 
--	[MIT License](LICENSE)
+-	[MIT License](LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
 httpcache
 =========
 
-[![Build Status](https://travis-ci.org/gregjones/httpcache.svg?branch=master)](https://travis-ci.org/gregjones/httpcache)
-
-A Transport for Go's http.Client that will cache responses according to the HTTP RFC
+[![Build Status](https://travis-ci.org/gregjones/httpcache.svg?branch=master)](https://travis-ci.org/gregjones/httpcache) [![GoDoc](https://godoc.org/github.com/gregjones/httpcache?status.svg)](https://godoc.org/github.com/gregjones/httpcache)
 
 Package httpcache provides a http.RoundTripper implementation that works as a mostly RFC-compliant cache for http responses.
 
 It is only suitable for use as a 'private' cache (i.e. for a web-browser or an API-client and not for a shared proxy).
 
-**Documentation:** http://godoc.org/github.com/gregjones/httpcache
-
-**License:** MIT (see LICENSE.txt)
-
-Cache backends
+Cache Backends
 --------------
 
 - The built-in 'memory' cache stores responses in an in-memory map.
@@ -23,3 +17,8 @@ Cache backends
 - [`github.com/gregjones/httpcache/leveldbcache`](https://github.com/gregjones/httpcache/tree/master/leveldbcache) provides a filesystem-backed cache using [leveldb](https://github.com/syndtr/goleveldb/leveldb).
 - [`github.com/die-net/lrucache`](https://github.com/die-net/lrucache) provides an in-memory cache that will evict least-recently used entries.
 - [`github.com/die-net/lrucache/twotier`](https://github.com/die-net/lrucache/tree/master/twotier) allows caches to be combined, for example to use lrucache above with a persistent disk-cache.
+
+License
+-------
+
+-	[MIT License](LICENSE)


### PR DESCRIPTION
- Remove the redundant `A Transport for Go's http.Client that will cache responses according to the HTTP RFC` sentence. The next paragraph says something similar. This sentence can already be found in the repository description (one liner):

    ![image](https://cloud.githubusercontent.com/assets/1924134/25060240/94e3a3f0-2166-11e7-8176-80c1e5349bc2.png)

- It's very common to find a godoc.org link in the form of a badge in most Go package repository READMEs. Therefore, it's more recognizable and easier to click the link. I think we should use the badge to be friendlier to users, and remove the superseded plain text link.

- Move License note into its own section at the bottom. This is a more common location. GitHub already detects and displays the license prominently in top right corner, and there is a LICENSE file in the repo, so it makes sense to place Cache Backends section higher up:

    ![image](https://cloud.githubusercontent.com/assets/1924134/25060250/ce4cf0ba-2166-11e7-9cf9-1c9116335d5e.png)

This PR is just a suggestion, feedback is welcome @gregjones.