### PR TITLE
Cache GET requests when body is fully read

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -11,6 +11,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -227,9 +229,25 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 				resp.Header.Set(fakeHeader, reqValue)
 			}
 		}
-		respBytes, err := httputil.DumpResponse(resp, true)
-		if err == nil {
-			t.Cache.Set(cacheKey, respBytes)
+		switch req.Method {
+		case "GET":
+			// Delay caching until EOF is reached.
+			resp.Body = &cachingReadCloser{
+				R: resp.Body,
+				OnEOF: func(r io.Reader) {
+					resp := *resp
+					resp.Body = ioutil.NopCloser(r)
+					respBytes, err := httputil.DumpResponse(&resp, true)
+					if err == nil {
+						t.Cache.Set(cacheKey, respBytes)
+					}
+				},
+			}
+		default:
+			respBytes, err := httputil.DumpResponse(resp, true)
+			if err == nil {
+				t.Cache.Set(cacheKey, respBytes)
+			}
 		}
 	} else {
 		t.Cache.Delete(cacheKey)
@@ -496,6 +514,35 @@ func headerAllCommaSepValues(headers http.Header, name string) []string {
 		vals = append(vals, fields...)
 	}
 	return vals
+}
+
+// cachingReadCloser is a wrapper around ReadCloser R that calls OnEOF
+// handler with a full copy of the content read from R when EOF is
+// reached.
+type cachingReadCloser struct {
+	// Underlying ReadCloser.
+	R io.ReadCloser
+	// OnEOF is called with a copy of the content of R when EOF is reached.
+	OnEOF func(io.Reader)
+
+	buf bytes.Buffer // buf stores a copy of the content of R.
+}
+
+// Read reads the next len(p) bytes from R or until R is drained. The
+// return value n is the number of bytes read. If R has no data to
+// return, err is io.EOF and OnEOF is called with a full copy of what
+// has been read so far.
+func (r *cachingReadCloser) Read(p []byte) (n int, err error) {
+	n, err = r.R.Read(p)
+	r.buf.Write(p[:n])
+	if err == io.EOF {
+		r.OnEOF(bytes.NewReader(r.buf.Bytes()))
+	}
+	return n, err
+}
+
+func (r *cachingReadCloser) Close() error {
+	return r.R.Close()
 }
 
 // NewMemoryCacheTransport returns a new Transport using the in-memory cache implementation


### PR DESCRIPTION
Lazy read GET response body and dump the full response in cache once EOF
has been read.

This fixes a bug with infinite stream that the cache tries to eager read
and save, and hangs the request.