### PR TITLE
Use method as cache key prefix for non-GET requests

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -41,7 +41,11 @@ type Cache interface {
 
 // cacheKey returns the cache key for req.
 func cacheKey(req *http.Request) string {
-	return req.URL.String()
+	if req.Method == http.MethodGet {
+		return req.URL.String()
+	} else {
+		return req.Method + " " + req.URL.String()
+	}
 }
 
 // CachedResponse returns the cached http.Response for req if present, and nil

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -225,16 +225,19 @@ func TestDontServeHeadResponseToGetRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.client.Do(req)
+	_, err = s.client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
 	req, err = http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := s.client.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Header.Get(XFromCache) != "" {
+	if resp.Header.Get(XFromCache) != "" {
 		t.Errorf("Cache should not match")
 	}
 }

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -218,6 +218,27 @@ func TestCacheableMethod(t *testing.T) {
 	}
 }
 
+func TestDontServeHeadResponseToGetRequest(t *testing.T) {
+	resetTest()
+	url := s.server.URL + "/"
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.client.Do(req)
+	req, err = http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Header.Get(XFromCache) != "" {
+		t.Errorf("Cache should not match")
+	}
+}
+
 func TestDontStorePartialRangeInCache(t *testing.T) {
 	resetTest()
 	{


### PR DESCRIPTION
The response for a `HEAD` request shouldn't be served in response to a `GET` request.

In practise, `HEAD` responses contain `http.noBody` values, which return `0, io.EOF` if you try to read them. Prior to this change, that's what happened if you hit a server with a `HEAD` request and then `GET` the same URI.

Rather than prefix all keys, I've only added prefixing to non-`GET` requests. As well as saving the cost of a string concatenation, it ensures existing disk caches can upgrade without completely invalidating.