### PR TITLE
Reduce memory use

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -55,7 +55,7 @@ func CachedResponse(c Cache, req *http.Request) (resp *http.Response, err error)
 		return
 	}
 
-	b := bytes.NewBuffer(cachedVal)
+	b := bytes.NewReader(cachedVal)
 	return http.ReadResponse(bufio.NewReader(b), req)
 }
 
@@ -452,9 +452,8 @@ func canStore(reqCacheControl, respCacheControl cacheControl) (canStore bool) {
 }
 
 func newGatewayTimeoutResponse(req *http.Request) *http.Response {
-	var braw bytes.Buffer
-	braw.WriteString("HTTP/1.1 504 Gateway Timeout\r\n\r\n")
-	resp, err := http.ReadResponse(bufio.NewReader(&braw), req)
+	braw := strings.NewReader("HTTP/1.1 504 Gateway Timeout\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(braw), req)
 	if err != nil {
 		panic(err)
 	}

--- a/httpcache.go
+++ b/httpcache.go
@@ -453,7 +453,7 @@ func canStore(reqCacheControl, respCacheControl cacheControl) (canStore bool) {
 
 func newGatewayTimeoutResponse(req *http.Request) *http.Response {
 	braw := strings.NewReader("HTTP/1.1 504 Gateway Timeout\r\n\r\n")
-	resp, err := http.ReadResponse(bufio.NewReader(braw), req)
+	resp, err := http.ReadResponse(bufio.NewReaderSize(braw, 0), req)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This pull request is split across three commits with each reducing wasteful memory allocations.

1. The first replaces the use of `*bytes.Buffer` with either `*bytes.Reader` or `*strings.Reader` as both structs are substantially smaller in size,
1.  The second reduces the `bufio.Reader` buffer size to 16-bytes, from 4096, in `newGatewayTimeoutResponse`, and
1. The third reduces the `bufio.Reader` buffer size to *at most* the size of the response in `CachedResponse`.

It's likely that further memory use reductions are possible, these are just the three that stood out to me.