### PR TITLE
Implement blocking transport

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -115,6 +115,12 @@ func NewTransport(c Cache) *Transport {
 func (t *Transport) Client() *http.Client {
 	return &http.Client{Transport: t}
 }
+func (t *BlockingTransport) transport() http.RoundTripper {
+	if t.Transport == nil {
+		return http.DefaultTransport
+	}
+	return t.Transport
+}
 
 // varyMatches will return false unless all of the cached values for the headers listed in Vary
 // match the new request
@@ -146,7 +152,6 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		// Need to invalidate an existing value
 		t.Cache.Delete(cacheKey)
 	}
-
 	transport := t.Transport
 	if transport == nil {
 		transport = http.DefaultTransport
@@ -212,6 +217,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			resp = newGatewayTimeoutResponse(req)
 		} else {
 			resp, err = transport.RoundTrip(req)
+			// resp, err = t.upstreamRoundTrip(cacheKey, req)
 			if err != nil {
 				return nil, err
 			}
@@ -548,4 +554,72 @@ func NewMemoryCacheTransport() *Transport {
 	c := NewMemoryCache()
 	t := NewTransport(c)
 	return t
+}
+
+type pending struct {
+	req *http.Request
+	buf *bytes.Buffer
+	err error
+	wg  sync.WaitGroup
+}
+type BlockingTransport struct {
+	mu        sync.RWMutex
+	pending   map[string]*pending
+	Transport http.RoundTripper
+}
+
+func NewBlockingTransport(rt http.RoundTripper) http.RoundTripper {
+	t := BlockingTransport{
+		pending:   make(map[string]*pending),
+		Transport: rt,
+	}
+	return &t
+}
+
+func (t *BlockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := cacheKey(req)
+	if key == "" {
+		return t.transport().RoundTrip(req)
+	}
+	var p *pending
+	t.mu.RLock()
+	p = t.pending[key]
+	t.mu.RUnlock()
+	if p != nil {
+		return p.Response()
+	}
+	t.mu.Lock()
+	if p = t.pending[key]; p != nil {
+		t.mu.Unlock()
+		return p.Response()
+	}
+	p = &pending{
+		req: req,
+		buf: new(bytes.Buffer),
+	}
+	p.wg.Add(1)
+	t.pending[key] = p
+	t.mu.Unlock()
+
+	go func() {
+		var resp *http.Response
+		if resp, p.err = t.transport().RoundTrip(p.req); p.err == nil {
+			p.err = resp.Write(p.buf)
+		}
+		t.mu.Lock()
+		delete(t.pending, key)
+		t.mu.Unlock()
+		p.wg.Done()
+	}()
+	return p.Response()
+}
+
+func (p *pending) Response() (*http.Response, error) {
+	p.wg.Wait()
+	if p.err != nil {
+		return nil, p.err
+	}
+	data := p.buf.Bytes()
+	r := bufio.NewReaderSize(bytes.NewReader(data), len(data))
+	return http.ReadResponse(r, p.req)
 }


### PR DESCRIPTION
This implements a `http.RoundTripper` wrapper to block multiple simultaneous upstream requests. Currently it's optional to use via `NewBlockingTransport` so as to not change the existing API.
Tries to solve Issue #60 