### PR TITLE
respect cacheable status codes

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -124,6 +124,13 @@ type Transport struct {
 // Opt is a config option func
 type Opt func(*Transport)
 
+// WithCacheableResponseCodes configures the set of response codes that are considered cacheable
+func WithCacheableResponseCodes(codes map[int]struct{}) Opt {
+	return func(t *Transport) {
+		t.cacheableResponseCodes = codes
+	}
+}
+
 // NewTransport returns a new Transport with the
 // provided Cache implementation and MarkCachedResponses set to true
 func NewTransport(c Cache, opts ...Opt) *Transport {


### PR DESCRIPTION
This PR is a rework of @rykov PR (credits for most of the changes go to him!).
- the default list of cacheable status codes is taken from #45, but the requested changes from https://github.com/gregjones/httpcache/pull/45#issuecomment-332335164 are taken into account
- the list of cacheable status codes is configurable via a variadic option func - this doesn't break the API
- based on the latest master (16.10.2018)

We had the need for the changes quite urgently, so I created the fork. I know this PR overrules #45 a bit. So I completely leave it up to you, if you think this PR contributes anything useful to the project I'd love to see it merged, if not and #45 is preferred, I'm happy as well.

Feedback/requests for change are welcome of cause.