### PR TITLE
move redis dependency to maintained repo

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,7 +2,7 @@
 package redis
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gregjones/httpcache"
 )
 

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 func TestRedisCache(t *testing.T) {


### PR DESCRIPTION
fixes a "use of internal package not allowed" error