### PR TITLE
test: Add a helper for testing cache implementations

### DIFF
--- a/diskcache/diskcache_test.go
+++ b/diskcache/diskcache_test.go
@@ -1,10 +1,11 @@
 package diskcache
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestDiskCache(t *testing.T) {
@@ -14,29 +15,5 @@ func TestDiskCache(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	cache := New(tempDir)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, New(tempDir))
 }

--- a/leveldbcache/leveldbcache_test.go
+++ b/leveldbcache/leveldbcache_test.go
@@ -1,11 +1,12 @@
 package leveldbcache
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestDiskCache(t *testing.T) {
@@ -20,27 +21,5 @@ func TestDiskCache(t *testing.T) {
 		t.Fatalf("New leveldb,: %v", err)
 	}
 
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, cache)
 }

--- a/memcache/appengine_test.go
+++ b/memcache/appengine_test.go
@@ -3,10 +3,10 @@
 package memcache
 
 import (
-	"bytes"
 	"testing"
 
 	"appengine/aetest"
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestAppEngine(t *testing.T) {
@@ -16,29 +16,5 @@ func TestAppEngine(t *testing.T) {
 	}
 	defer ctx.Close()
 
-	cache := New(ctx)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, New(ctx))
 }

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -3,9 +3,10 @@
 package memcache
 
 import (
-	"bytes"
 	"net"
 	"testing"
+
+	"github.com/gregjones/httpcache/test"
 )
 
 const testServer = "localhost:11211"
@@ -19,29 +20,5 @@ func TestMemCache(t *testing.T) {
 	conn.Write([]byte("flush_all\r\n")) // flush memcache
 	conn.Close()
 
-	cache := New(testServer)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, New(testServer))
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,10 +1,10 @@
 package redis
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestRedisCache(t *testing.T) {
@@ -15,29 +15,5 @@ func TestRedisCache(t *testing.T) {
 	}
 	conn.Do("FLUSHALL")
 
-	cache := NewWithClient(conn)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, NewWithClient(conn))
 }

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gregjones/httpcache"
+)
+
+// Cache excercises a httpcache.Cache implementation.
+func Cache(t *testing.T, cache httpcache.Cache) {
+	key := "testKey"
+	_, ok := cache.Get(key)
+	if ok {
+		t.Fatal("retrieved key before adding it")
+	}
+
+	val := []byte("some bytes")
+	cache.Set(key, val)
+
+	retVal, ok := cache.Get(key)
+	if !ok {
+		t.Fatal("could not retrieve an element we just added")
+	}
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
+	}
+
+	cache.Delete(key)
+
+	_, ok = cache.Get(key)
+	if ok {
+		t.Fatal("deleted key still present")
+	}
+}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,0 +1,12 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/gregjones/httpcache"
+	"github.com/gregjones/httpcache/test"
+)
+
+func TestMemoryCache(t *testing.T) {
+	test.Cache(t, httpcache.NewMemoryCache())
+}


### PR DESCRIPTION
This DRYs things up a bit (and gives me a single place to edit the tests when I get around to streaming caches, #85).