### PR TITLE
.travis.yml: Bump to Go 1.11, return to 'gofmt -s', and update the format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d .)
+  - diff -u <(echo -n) <(gofmt -d -s .)
   - go tool vet .
   - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - master
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 sudo: false
 language: go
-go:
-  - 1.10.x
-  - 1.11.x
-  - master
 matrix:
   allow_failures:
     - go: master
   fast_finish: true
+  include:
+    - go: 1.10.x
+    - go: 1.11.x
+      env: GOFMT=1
+    - go: master
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d -s .)
+  - if test -n "${GOFMT}"; then gofmt -w -s . && git diff --exit-code; fi
   - go tool vet .
   - go test -v -race ./...

--- a/httpcache.go
+++ b/httpcache.go
@@ -416,14 +416,14 @@ func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
 func getEndToEndHeaders(respHeaders http.Header) []string {
 	// These headers are always hop-by-hop
 	hopByHopHeaders := map[string]struct{}{
-		"Connection":          struct{}{},
-		"Keep-Alive":          struct{}{},
-		"Proxy-Authenticate":  struct{}{},
-		"Proxy-Authorization": struct{}{},
-		"Te":                struct{}{},
-		"Trailers":          struct{}{},
-		"Transfer-Encoding": struct{}{},
-		"Upgrade":           struct{}{},
+		"Connection":          {},
+		"Keep-Alive":          {},
+		"Proxy-Authenticate":  {},
+		"Proxy-Authorization": {},
+		"Te":                  {},
+		"Trailers":            {},
+		"Transfer-Encoding":   {},
+		"Upgrade":             {},
 	}
 
 	for _, extra := range strings.Split(respHeaders.Get("connection"), ",") {
@@ -433,7 +433,7 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 		}
 	}
 	endToEndHeaders := []string{}
-	for respHeader, _ := range respHeaders {
+	for respHeader := range respHeaders {
 		if _, ok := hopByHopHeaders[respHeader]; !ok {
 			endToEndHeaders = append(endToEndHeaders, respHeader)
 		}


### PR DESCRIPTION
In three commits:

1. 459ce58, bumping the Go versions, which I wrote by hand.
2. 118c0b1, reverting be6978e2 (#40).
3. 9f73bc1, with the `gofmt` changes.

Details on each in the commit messages.