### PR TITLE
Streaming caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 sudo: false
 language: go
-go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - master
 matrix:
   allow_failures:
     - go: master
   fast_finish: true
+  include:
+    - go: 1.10.x
+    - go: 1.11.x
+      env: GOFMT=1
+    - go: master
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d .)
+  - if test -n "${GOFMT}"; then gofmt -w -s . && git diff --exit-code; fi
   - go tool vet .
   - go test -v -race ./...

--- a/bufferedstreamingcache.go
+++ b/bufferedstreamingcache.go
@@ -1,0 +1,56 @@
+package httpcache
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// BufferedStreamingCache converts a Cache into a StreamingCache by using in-memory buffers.
+type BufferedStreamingCache struct {
+	cache Cache
+}
+
+// NewBufferedStreamingCache(cache Cache) wraps a Cache in a BufferedStreamingCache.
+func NewBufferedStreamingCache(cache Cache) StreamingCache {
+	return &BufferedStreamingCache{cache: cache}
+}
+
+// Get returns the []byte representation of a cached response and a bool
+// set to true if the value isn't empty.
+func (c *BufferedStreamingCache) Get(key string) (responseBytes []byte, ok bool) {
+	return c.cache.Get(key)
+}
+
+// Set stores the []byte representation of a response against a key.
+func (c *BufferedStreamingCache) Set(key string, responseBytes []byte) {
+	c.cache.Set(key, responseBytes)
+}
+
+// Delete removes the value associated with the key.
+func (c *BufferedStreamingCache) Delete(key string) {
+	c.cache.Delete(key)
+}
+
+// GetReader streams data from the cache.  Returns os.ErrNotExist on cache misses.
+func (c *BufferedStreamingCache) GetReader(key string) (response io.ReadCloser, err error) {
+	data, ok := c.cache.Get(key)
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	reader := bytes.NewBuffer(data)
+	return ioutil.NopCloser(reader), nil
+}
+
+// SetReader streams data into the cache.
+func (c *BufferedStreamingCache) SetReader(key string, reader io.Reader) (err error) {
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+
+	c.cache.Set(key, data)
+	return nil
+}

--- a/diskcache/diskcache.go
+++ b/diskcache/diskcache.go
@@ -26,10 +26,22 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return resp, true
 }
 
+// GetReader streams data from the cache.
+func (c *Cache) GetReader(key string) (reader io.ReadCloser, err error) {
+	key = keyToFilename(key)
+	return c.d.ReadStream(key, true) // FIXME: what direct value do we want?
+}
+
 // Set saves a response to the cache as key
 func (c *Cache) Set(key string, resp []byte) {
 	key = keyToFilename(key)
 	c.d.WriteStream(key, bytes.NewReader(resp), true)
+}
+
+// SetReader streams data into the cache.
+func (c *Cache) SetReader(key string, input io.Reader) (err error) {
+	key = keyToFilename(key)
+	return c.d.WriteStream(key, input, true)
 }
 
 // Delete removes the response with key from the cache

--- a/diskcache/diskcache_test.go
+++ b/diskcache/diskcache_test.go
@@ -1,10 +1,11 @@
 package diskcache
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestDiskCache(t *testing.T) {
@@ -14,29 +15,5 @@ func TestDiskCache(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	cache := New(tempDir)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, New(tempDir))
 }

--- a/diskcache/diskcache_test.go
+++ b/diskcache/diskcache_test.go
@@ -15,5 +15,5 @@ func TestDiskCache(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	test.Cache(t, New(tempDir))
+	test.StreamingCache(t, New(tempDir))
 }

--- a/httpcache.go
+++ b/httpcache.go
@@ -416,14 +416,14 @@ func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
 func getEndToEndHeaders(respHeaders http.Header) []string {
 	// These headers are always hop-by-hop
 	hopByHopHeaders := map[string]struct{}{
-		"Connection":          struct{}{},
-		"Keep-Alive":          struct{}{},
-		"Proxy-Authenticate":  struct{}{},
-		"Proxy-Authorization": struct{}{},
-		"Te":                struct{}{},
-		"Trailers":          struct{}{},
-		"Transfer-Encoding": struct{}{},
-		"Upgrade":           struct{}{},
+		"Connection":          {},
+		"Keep-Alive":          {},
+		"Proxy-Authenticate":  {},
+		"Proxy-Authorization": {},
+		"Te":                  {},
+		"Trailers":            {},
+		"Transfer-Encoding":   {},
+		"Upgrade":             {},
 	}
 
 	for _, extra := range strings.Split(respHeaders.Get("connection"), ",") {
@@ -433,7 +433,7 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 		}
 	}
 	endToEndHeaders := []string{}
-	for respHeader, _ := range respHeaders {
+	for respHeader := range respHeaders {
 		if _, ok := hopByHopHeaders[respHeader]; !ok {
 			endToEndHeaders = append(endToEndHeaders, respHeader)
 		}

--- a/httpcache.go
+++ b/httpcache.go
@@ -10,10 +10,11 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -38,28 +39,47 @@ type Cache interface {
 	Delete(key string)
 }
 
-// cacheKey returns the cache key for req.
-func cacheKey(req *http.Request) string {
-	if req.Method == http.MethodGet {
-		return req.URL.String()
-	} else {
-		return req.Method + " " + req.URL.String()
-	}
+// A StreamingCache interface is used by the Transport to store and retrieve responses.
+type StreamingCache interface {
+	Cache
+
+	// GetReader streams data from the cache.  Returns os.ErrNotExist on cache misses.
+	GetReader(key string) (response io.ReadCloser, err error)
+
+	// SetReader streams data into the cache.
+	SetReader(key string, input io.Reader) error
+}
+
+// cacheKey returns the cache keys for req.
+func cacheKey(req *http.Request) (header string, body string) {
+	key := fmt.Sprintf("%s-%s", req.Method, req.URL.String())
+	return fmt.Sprintf("header-%s", key), fmt.Sprintf("body-%s", key)
 }
 
 // CachedResponse returns the cached http.Response for req if present, and nil
 // otherwise.
-func CachedResponse(c Cache, req *http.Request) (resp *http.Response, err error) {
-	cachedVal, ok := c.Get(cacheKey(req))
+func CachedResponse(c StreamingCache, req *http.Request) (resp *http.Response, err error) {
+	headerKey, bodyKey := cacheKey(req)
+	header, ok := c.Get(headerKey)
 	if !ok {
 		return
 	}
 
-	b := bytes.NewBuffer(cachedVal)
-	return http.ReadResponse(bufio.NewReader(b), req)
+	body, err := c.GetReader(bodyKey)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	b := bytes.NewBuffer(header)
+	resp, err = http.ReadResponse(bufio.NewReader(b), req)
+	resp.Body = body
+	return resp, err
 }
 
-// MemoryCache is an implemtation of Cache that stores responses in an in-memory map.
+// MemoryCache is an implementation of Cache that stores responses in an in-memory map.
 type MemoryCache struct {
 	mu    sync.RWMutex
 	items map[string][]byte
@@ -100,14 +120,14 @@ type Transport struct {
 	// The RoundTripper interface actually used to make requests
 	// If nil, http.DefaultTransport is used
 	Transport http.RoundTripper
-	Cache     Cache
+	Cache     StreamingCache
 	// If true, responses returned from the cache will be given an extra header, X-From-Cache
 	MarkCachedResponses bool
 }
 
 // NewTransport returns a new Transport with the
 // provided Cache implementation and MarkCachedResponses set to true
-func NewTransport(c Cache) *Transport {
+func NewTransport(c StreamingCache) *Transport {
 	return &Transport{Cache: c, MarkCachedResponses: true}
 }
 
@@ -137,7 +157,7 @@ func varyMatches(cachedResp *http.Response, req *http.Request) bool {
 // to give the server a chance to respond with NotModified. If this happens, then the cached Response
 // will be returned.
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	cacheKey := cacheKey(req)
+	headerKey, bodyKey := cacheKey(req)
 
 	transport := t.Transport
 	if transport == nil {
@@ -146,7 +166,8 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 
 	cacheable := (req.Method == "GET" || req.Method == "HEAD") && req.Header.Get("range") == ""
 	if !cacheable {
-		t.Cache.Delete(cacheKey)
+		t.Cache.Delete(headerKey)
+		t.Cache.Delete(bodyKey)
 		return transport.RoundTrip(req)
 	}
 
@@ -205,7 +226,8 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 				// when available
 				return cachedResp, nil
 			}
-			t.Cache.Delete(cacheKey)
+			t.Cache.Delete(headerKey)
+			t.Cache.Delete(bodyKey)
 			return resp, err
 		}
 
@@ -221,12 +243,14 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			// when available
 			return cachedResp, nil
 		} else if resp.StatusCode != http.StatusOK {
-			t.Cache.Delete(cacheKey)
+			t.Cache.Delete(headerKey)
+			t.Cache.Delete(bodyKey)
 		}
 	}
 
 	if !canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header)) {
-		t.Cache.Delete(cacheKey)
+		t.Cache.Delete(headerKey)
+		t.Cache.Delete(bodyKey)
 		return resp, nil
 	}
 
@@ -238,27 +262,18 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			resp.Header.Set(fakeHeader, reqValue)
 		}
 	}
-	switch req.Method {
-	case "GET":
-		// Delay caching until EOF is reached.
-		resp.Body = &cachingReadCloser{
-			R: resp.Body,
-			OnEOF: func(r io.Reader) {
-				resp := *resp
-				resp.Body = ioutil.NopCloser(r)
-				respBytes, err := httputil.DumpResponse(&resp, true)
-				if err == nil {
-					t.Cache.Set(cacheKey, respBytes)
-				}
-			},
-		}
-	default:
-		respBytes, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return resp, err
-		}
-		t.Cache.Set(cacheKey, respBytes)
+
+	t.Cache.Delete(headerKey)
+	t.Cache.Delete(bodyKey)
+	headerBytes, err := httputil.DumpResponse(resp, false)
+	if err != nil {
+		return resp, err
 	}
+	t.Cache.Set(headerKey, headerBytes)
+
+	resp.Body = stream(resp.Body, func(pipeReader io.ReadCloser) error {
+		return t.Cache.SetReader(bodyKey, pipeReader)
+	})
 
 	return resp, nil
 }
@@ -528,38 +543,9 @@ func headerAllCommaSepValues(headers http.Header, name string) []string {
 	return vals
 }
 
-// cachingReadCloser is a wrapper around ReadCloser R that calls OnEOF
-// handler with a full copy of the content read from R when EOF is
-// reached.
-type cachingReadCloser struct {
-	// Underlying ReadCloser.
-	R io.ReadCloser
-	// OnEOF is called with a copy of the content of R when EOF is reached.
-	OnEOF func(io.Reader)
-
-	buf bytes.Buffer // buf stores a copy of the content of R.
-}
-
-// Read reads the next len(p) bytes from R or until R is drained. The
-// return value n is the number of bytes read. If R has no data to
-// return, err is io.EOF and OnEOF is called with a full copy of what
-// has been read so far.
-func (r *cachingReadCloser) Read(p []byte) (n int, err error) {
-	n, err = r.R.Read(p)
-	r.buf.Write(p[:n])
-	if err == io.EOF {
-		r.OnEOF(bytes.NewReader(r.buf.Bytes()))
-	}
-	return n, err
-}
-
-func (r *cachingReadCloser) Close() error {
-	return r.R.Close()
-}
-
 // NewMemoryCacheTransport returns a new Transport using the in-memory cache implementation
 func NewMemoryCacheTransport() *Transport {
-	c := NewMemoryCache()
+	c := NewBufferedStreamingCache(NewMemoryCache())
 	t := NewTransport(c)
 	return t
 }

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -166,7 +166,7 @@ func teardown() {
 }
 
 func resetTest() {
-	s.transport.Cache = NewMemoryCache()
+	s.transport.Cache = NewBufferedStreamingCache(NewMemoryCache())
 	clock = &realClock{}
 }
 

--- a/leveldbcache/leveldbcache_test.go
+++ b/leveldbcache/leveldbcache_test.go
@@ -1,11 +1,12 @@
 package leveldbcache
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestDiskCache(t *testing.T) {
@@ -20,27 +21,5 @@ func TestDiskCache(t *testing.T) {
 		t.Fatalf("New leveldb,: %v", err)
 	}
 
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, cache)
 }

--- a/leveldbcache/leveldbcache_test.go
+++ b/leveldbcache/leveldbcache_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/test"
 )
 
@@ -21,5 +22,5 @@ func TestDiskCache(t *testing.T) {
 		t.Fatalf("New leveldb,: %v", err)
 	}
 
-	test.Cache(t, cache)
+	test.StreamingCache(t, httpcache.NewBufferedStreamingCache(cache))
 }

--- a/memcache/appengine_test.go
+++ b/memcache/appengine_test.go
@@ -3,10 +3,10 @@
 package memcache
 
 import (
-	"bytes"
 	"testing"
 
 	"appengine/aetest"
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestAppEngine(t *testing.T) {
@@ -16,29 +16,5 @@ func TestAppEngine(t *testing.T) {
 	}
 	defer ctx.Close()
 
-	cache := New(ctx)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, New(ctx))
 }

--- a/memcache/appengine_test.go
+++ b/memcache/appengine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"appengine/aetest"
+	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/test"
 )
 
@@ -16,5 +17,5 @@ func TestAppEngine(t *testing.T) {
 	}
 	defer ctx.Close()
 
-	test.Cache(t, New(ctx))
+	test.StreamingCache(t, httpcache.NewBufferedStreamingCache(New(ctx)))
 }

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -3,9 +3,10 @@
 package memcache
 
 import (
-	"bytes"
 	"net"
 	"testing"
+
+	"github.com/gregjones/httpcache/test"
 )
 
 const testServer = "localhost:11211"
@@ -19,29 +20,5 @@ func TestMemCache(t *testing.T) {
 	conn.Write([]byte("flush_all\r\n")) // flush memcache
 	conn.Close()
 
-	cache := New(testServer)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, New(testServer))
 }

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/test"
 )
 
@@ -20,5 +21,5 @@ func TestMemCache(t *testing.T) {
 	conn.Write([]byte("flush_all\r\n")) // flush memcache
 	conn.Close()
 
-	test.Cache(t, New(testServer))
+	test.StreamingCache(t, httpcache.NewBufferedStreamingCache(New(testServer)))
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,7 +2,7 @@
 package redis
 
 import (
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gregjones/httpcache"
 )
 

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/test"
 )
 
@@ -15,5 +16,5 @@ func TestRedisCache(t *testing.T) {
 	}
 	conn.Do("FLUSHALL")
 
-	test.Cache(t, NewWithClient(conn))
+	test.StreamingCache(t, httpcache.NewBufferedStreamingCache(NewWithClient(conn)))
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,10 +1,10 @@
 package redis
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/garyburd/redigo/redis"
+	"github.com/gregjones/httpcache/test"
 )
 
 func TestRedisCache(t *testing.T) {
@@ -15,29 +15,5 @@ func TestRedisCache(t *testing.T) {
 	}
 	conn.Do("FLUSHALL")
 
-	cache := NewWithClient(conn)
-
-	key := "testKey"
-	_, ok := cache.Get(key)
-	if ok {
-		t.Fatal("retrieved key before adding it")
-	}
-
-	val := []byte("some bytes")
-	cache.Set(key, val)
-
-	retVal, ok := cache.Get(key)
-	if !ok {
-		t.Fatal("could not retrieve an element we just added")
-	}
-	if !bytes.Equal(retVal, val) {
-		t.Fatal("retrieved a different value than what we put in")
-	}
-
-	cache.Delete(key)
-
-	_, ok = cache.Get(key)
-	if ok {
-		t.Fatal("deleted key still present")
-	}
+	test.Cache(t, NewWithClient(conn))
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"testing"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/gregjones/httpcache/test"
 )
 

--- a/streamreader.go
+++ b/streamreader.go
@@ -1,0 +1,73 @@
+package httpcache
+
+import (
+	"errors"
+	"io"
+)
+
+// streamReader fans out a source ReadCloser into two consumers.
+//
+// https://github.com/golang/go/issues/9051#issue-51289031
+type streamReader struct {
+	sourceCloser  io.Closer
+	teeReader     io.Reader
+	pipeReader    *io.PipeReader
+	pipeWriter    *io.PipeWriter
+	handlerErrors chan error
+}
+
+var closedEarly = errors.New("closed before EOF")
+
+// Read pulls data from the source reader.  Besides being returned
+// here, it will also be pushed into the pipe for the handler to pick
+// up.
+func (r *streamReader) Read(data []byte) (n int, err error) {
+	n, err = r.teeReader.Read(data)
+	if err == io.EOF {
+		r.pipeWriter.Close()
+		r.pipeWriter = nil
+		err = <-r.handlerErrors
+		if err != nil {
+			return n, err
+		}
+		return n, io.EOF
+	}
+	return n, err
+}
+
+// Close closes the source reader and the pipe.  The handler reader FIXME
+func (r *streamReader) Close() (err error) {
+	err = r.sourceCloser.Close()
+	if err != nil {
+		if r.pipeWriter != nil {
+			r.pipeWriter.CloseWithError(err)
+		}
+		return err
+	}
+
+	if r.pipeWriter != nil {
+		err = r.pipeWriter.CloseWithError(closedEarly)
+		if err != nil {
+			return err
+		}
+
+		return <-r.handlerErrors
+	}
+
+	return nil
+}
+
+func stream(readCloser io.ReadCloser, handler func(io.ReadCloser) error) *streamReader {
+	pipeReader, pipeWriter := io.Pipe()
+	handlerErrors := make(chan error, 1)
+	go func() {
+		handlerErrors <- handler(pipeReader)
+	}()
+	return &streamReader{
+		sourceCloser:  readCloser,
+		teeReader:     io.TeeReader(readCloser, pipeWriter),
+		pipeReader:    pipeReader,
+		pipeWriter:    pipeWriter,
+		handlerErrors: handlerErrors,
+	}
+}

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gregjones/httpcache"
+)
+
+// Cache excercises a httpcache.Cache implementation.
+func Cache(t *testing.T, cache httpcache.Cache) {
+	key := "testKey"
+	_, ok := cache.Get(key)
+	if ok {
+		t.Fatal("retrieved key before adding it")
+	}
+
+	val := []byte("some bytes")
+	cache.Set(key, val)
+
+	retVal, ok := cache.Get(key)
+	if !ok {
+		t.Fatal("could not retrieve an element we just added")
+	}
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
+	}
+
+	cache.Delete(key)
+
+	_, ok = cache.Get(key)
+	if ok {
+		t.Fatal("deleted key still present")
+	}
+}

--- a/test/test.go
+++ b/test/test.go
@@ -2,13 +2,15 @@ package test
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/gregjones/httpcache"
 )
 
-// Cache excercises a httpcache.Cache implementation.
-func Cache(t *testing.T, cache httpcache.Cache) {
+// StreamingCache excercises a httpcache.StreamingCache implementation.
+func StreamingCache(t *testing.T, cache httpcache.StreamingCache) {
 	key := "testKey"
 	_, ok := cache.Get(key)
 	if ok {
@@ -31,5 +33,29 @@ func Cache(t *testing.T, cache httpcache.Cache) {
 	_, ok = cache.Get(key)
 	if ok {
 		t.Fatal("deleted key still present")
+	}
+
+	reader, err := cache.GetReader(key)
+	if !os.IsNotExist(err) {
+		t.Fatalf("deleted key still present: %s", err)
+	}
+
+	err = cache.SetReader(key, bytes.NewBuffer(val))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err = cache.GetReader(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retVal, err = ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(retVal, val) {
+		t.Fatal("retrieved a different value than what we put in")
 	}
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,0 +1,12 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/gregjones/httpcache"
+	"github.com/gregjones/httpcache/test"
+)
+
+func TestMemoryCache(t *testing.T) {
+	test.Cache(t, httpcache.NewMemoryCache())
+}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -8,5 +8,5 @@ import (
 )
 
 func TestMemoryCache(t *testing.T) {
-	test.Cache(t, httpcache.NewMemoryCache())
+	test.StreamingCache(t, httpcache.NewBufferedStreamingCache(httpcache.NewMemoryCache()))
 }


### PR DESCRIPTION
For backends that support it, avoid holding the whole response body in memory.  This is much more efficient when shipping around large files on hosts without lots of memory.

For backends that don't support streaming (currently all except diskcache), this is not much of a change.  The new BufferedStreamingCache wrapper just collects the buffering logic in a different place.

The streaming body is cached when the pipe is closed with a successful "consumer read the whole body" EOF.  But because the handler is running in a goroutine, we need a channel to wait out the handler exit before continuing in the caller.  I initially only read from the handlerErrors channel in streamReader.Close and left streamReader.Read errors asynchronous.  But a number of the unit tests are structured:

```go
{
  // first request
  ...
  defer resp.Body.Close()
  ...
}
{
  // second request
}
```

But defered functions do not fire on those scope exits:

```console
$ cat test.go
package main

import "fmt"

func main() {
  {
    defer fmt.Println("a")
  }
  fmt.Println("b")
}
$ go run test.go
b
a
$ go version
go version go1.10.3 linux/amd64
```

You could force the defers to fire with:

```go
func() {
  // first request
  ...
  defer resp.Body.Close()
  ...
}()
```

but adding channel readers to both `Read()` and `Close()` ensures we sync with the handler exit on either EOF or early-close.

Fixes #82.
Fixes #85.

Builds on #89, #90, #91, and #92; review those first.