### PR TITLE
Fix unclosed response bodies that are not being used

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -192,11 +192,15 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			for _, header := range endToEndHeaders {
 				cachedResp.Header[header] = resp.Header[header]
 			}
+			resp.Body.Close()
 			resp = cachedResp
 		} else if (err != nil || (cachedResp != nil && resp.StatusCode >= 500)) &&
 			req.Method == "GET" && canStaleOnError(cachedResp.Header, req.Header) {
 			// In case of transport failure and stale-if-error activated, returns cached content
 			// when available
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
 			return cachedResp, nil
 		} else {
 			if err != nil || resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
Using this library, we noticed a memory leak.
We traced it too these response bodies not being able to be closed (becuase they are never passed back)