### PR TITLE
Allow recognizing responses that got re-validated

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -25,6 +25,8 @@ const (
 	transparent
 	// XFromCache is the header added to responses that are returned from the cache
 	XFromCache = "X-From-Cache"
+	// XRevalidated is the header added to responses that got revalidated
+	XRevalidated = "X-Revalidated"
 )
 
 // A Cache interface is used by the Transport to store and retrieve responses.
@@ -191,6 +193,9 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			endToEndHeaders := getEndToEndHeaders(resp.Header)
 			for _, header := range endToEndHeaders {
 				cachedResp.Header[header] = resp.Header[header]
+			}
+			if t.MarkCachedResponses {
+				cachedResp.Header[XRevalidated] = []string{"1"}
 			}
 			resp = cachedResp
 		} else if (err != nil || (cachedResp != nil && resp.StatusCode >= 500)) &&

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -564,6 +564,9 @@ func TestGetWithEtag(t *testing.T) {
 		if resp.Header.Get(XFromCache) != "1" {
 			t.Fatalf(`XFromCache header isn't "1": %v`, resp.Header.Get(XFromCache))
 		}
+		if resp.Header.Get(XRevalidated) != "1" {
+			t.Fatalf(`XRevalidated isn't "1": %v`, resp.Header.Get(XRevalidated))
+		}
 		// additional assertions to verify that 304 response is converted properly
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("response status code isn't 200 OK: %v", resp.StatusCode)


### PR DESCRIPTION
When MarkCacheResponse is set, this change will add a header if a
response got revalidated, so that consumers can detect that.

/cc @gregjones