### PR TITLE
Support stale-while-revalidate

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -19,12 +19,17 @@ import (
 	"time"
 )
 
+type Freshness string
+
 const (
-	stale = iota
-	fresh
-	transparent
+	stale                Freshness = "stale"
+	staleWhileRevalidate Freshness = "stale-while-revalidate"
+	fresh                Freshness = "fresh"
+	transparent          Freshness = "transparent"
+
 	// XFromCache is the header added to responses that are returned from the cache
 	XFromCache = "X-From-Cache"
+	XFreshness = "X-Cache-Freshness"
 )
 
 // A Cache interface is used by the Transport to store and retrieve responses.
@@ -160,7 +165,28 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		if varyMatches(cachedResp, req) {
 			// Can only use cached value if the new request doesn't Vary significantly
 			freshness := getFreshness(cachedResp.Header, req.Header)
+			if t.MarkCachedResponses {
+				cachedResp.Header.Set(XFreshness, string(freshness))
+			}
+
 			if freshness == fresh {
+				return cachedResp, nil
+			} else if freshness == staleWhileRevalidate {
+				noCacheRequest := *req
+				noCacheRequest.Header = noCacheRequest.Header.Clone()
+				noCacheRequest.Header.Set("cache-control", "no-cache")
+				go func() {
+					resp, err := t.RoundTrip(&noCacheRequest)
+					if err == nil {
+						defer resp.Body.Close()
+						buffer := make([]byte, 4096)
+						for {
+							if _, err = resp.Body.Read(buffer); err == io.EOF {
+								break
+							}
+						}
+					}
+				}()
 				return cachedResp, nil
 			}
 
@@ -288,7 +314,7 @@ var clock timer = &realClock{}
 //
 // Because this is only a private cache, 'public' and 'private' in cache-control aren't
 // signficant. Similarly, smax-age isn't used.
-func getFreshness(respHeaders, reqHeaders http.Header) (freshness int) {
+func getFreshness(respHeaders, reqHeaders http.Header) Freshness {
 	respCacheControl := parseCacheControl(respHeaders)
 	reqCacheControl := parseCacheControl(reqHeaders)
 	if _, ok := reqCacheControl["no-cache"]; ok {
@@ -364,6 +390,16 @@ func getFreshness(respHeaders, reqHeaders http.Header) (freshness int) {
 
 	if lifetime > currentAge {
 		return fresh
+	}
+
+	if stalewhilerevalidate, ok := respCacheControl["stale-while-revalidate"]; ok {
+		// If the cached response isn't too stale, we can return it and refresh asynchronously
+		stalewhilerevalidateDuration, err := time.ParseDuration(stalewhilerevalidate + "s")
+		if err == nil {
+			if lifetime+stalewhilerevalidateDuration > currentAge {
+				return staleWhileRevalidate
+			}
+		}
 	}
 
 	return stale


### PR DESCRIPTION
stale-while-revalidate allows resources that are accessed often to be refreshed asynchronously.

This is implemented by a new freshness state that returns the cached response, but triggers an asynchronous request that gets stored in the cache.

## Example

If we need to call an external service to generate short-lived user JWT tokens (e.g., valid for a minute)

Imagine this request is slow and needs to be cached so the app is more responsive. However we don't want the app to hang every minute when the JWT token expires, so it needs to be refreshed asynchronously.

Instead of returning `cache-control: max-age=60`, it can now return `cache-control: max-age=30, stale-while-revalidate=30`, so that JWT tokens for users making frequent requests are regenerated every ~30s.

(If the user stays away for over a minute the next request will be slow)